### PR TITLE
Problem read profile data

### DIFF
--- a/development/src/main/java/gurux/dlms/objects/GXDLMSProfileGeneric.java
+++ b/development/src/main/java/gurux/dlms/objects/GXDLMSProfileGeneric.java
@@ -542,7 +542,7 @@ public class GXDLMSProfileGeneric extends GXDLMSObject implements IGXDLMSBase {
                             .getValue();
             for (Object row : getBuffer()) {
                 java.util.Date tm;
-                Object tmp = ((Object[]) row)[0];
+                Object tmp = ((Object[]) row)[this.getSortObjectDataIndex()];
                 if (tmp instanceof GXDateTime) {
                     tm = ((GXDateTime) tmp).getValue();
                 } else {


### PR DESCRIPTION
There is a problem reading generic profile data (using range selector)
when the sort object is not the first object in capture buffer. The code
always use the first object.
